### PR TITLE
(refactor): Update controller_test.go to use NewInMemoryAct, modify Session.Key to return correct dimensional byte slice

### DIFF
--- a/pkg/dynamicaccess/controller_test.go
+++ b/pkg/dynamicaccess/controller_test.go
@@ -22,11 +22,9 @@ func mockTestHistory(key, val []byte) dynamicaccess.History {
 	var (
 		h   = mock.NewHistory()
 		now = time.Now()
-		act = mock.NewActMock(nil, func(lookupKey []byte) ([]byte, error) {
-			return val, nil
-		})
+		act = dynamicaccess.NewInMemoryAct()
 	)
-	// act.Add(key, val)
+	act.Add(key, val)
 	h.Insert(now.AddDate(-3, 0, 0).Unix(), act)
 	return h
 }
@@ -36,11 +34,11 @@ func TestDecrypt(t *testing.T) {
 	ak := encryption.Key([]byte("cica"))
 
 	si := dynamicaccess.NewDefaultSession(pk)
-	aek, _ := si.Key(&pk.PublicKey, [][]byte{{1}})
-	e2 := encryption.New(aek[0], 0, uint32(0), hashFunc)
+	aek, _ := si.Key(&pk.PublicKey, [][]byte{{0}, {1}})
+	e2 := encryption.New(aek[1], 0, uint32(0), hashFunc)
 	peak, _ := e2.Encrypt(ak)
 
-	h := mockTestHistory(nil, peak)
+	h := mockTestHistory(aek[0], peak)
 	al := setupAccessLogic(pk)
 	gm := dynamicaccess.NewGranteeManager(al)
 	c := dynamicaccess.NewController(h, gm, al)
@@ -62,11 +60,11 @@ func TestEncrypt(t *testing.T) {
 	ak := encryption.Key([]byte("cica"))
 
 	si := dynamicaccess.NewDefaultSession(pk)
-	aek, _ := si.Key(&pk.PublicKey, [][]byte{{1}})
-	e2 := encryption.New(aek[0], 0, uint32(0), hashFunc)
+	aek, _ := si.Key(&pk.PublicKey, [][]byte{{0}, {1}})
+	e2 := encryption.New(aek[1], 0, uint32(0), hashFunc)
 	peak, _ := e2.Encrypt(ak)
 
-	h := mockTestHistory(nil, peak)
+	h := mockTestHistory(aek[0], peak)
 	al := setupAccessLogic(pk)
 	gm := dynamicaccess.NewGranteeManager(al)
 	c := dynamicaccess.NewController(h, gm, al)

--- a/pkg/dynamicaccess/session.go
+++ b/pkg/dynamicaccess/session.go
@@ -27,12 +27,14 @@ func (s *session) Key(publicKey *ecdsa.PublicKey, nonces [][]byte) ([][]byte, er
 	}
 
 	keys := make([][]byte, len(nonces))
+	ix := 0
 	for _, nonce := range nonces {
 		key, err := crypto.LegacyKeccak256(append(x.Bytes(), nonce...))
 		if err != nil {
 			return nil, err
 		}
-		keys = append(keys, key)
+		keys[ix] = key
+		ix++
 	}
 
 	return keys, nil

--- a/pkg/dynamicaccess/session.go
+++ b/pkg/dynamicaccess/session.go
@@ -26,15 +26,13 @@ func (s *session) Key(publicKey *ecdsa.PublicKey, nonces [][]byte) ([][]byte, er
 		return nil, errors.New("shared secret is point at infinity")
 	}
 
-	keys := make([][]byte, len(nonces))
-	ix := 0
+	keys := make([][]byte, 0, len(nonces))
 	for _, nonce := range nonces {
 		key, err := crypto.LegacyKeccak256(append(x.Bytes(), nonce...))
 		if err != nil {
 			return nil, err
 		}
-		keys[ix] = key
-		ix++
+		keys = append(keys, key)
 	}
 
 	return keys, nil


### PR DESCRIPTION
…ession.Key to return two-dimensional byte slice

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
